### PR TITLE
Takes cases where no instruction provided or incorrect casing for instruction

### DIFF
--- a/lib/maqe-bot.js
+++ b/lib/maqe-bot.js
@@ -52,11 +52,17 @@ class MAQEBOT {
             this._whatDirectionShouldITake(RIGHT);
         } else if (action === WALK) {
             this._whatStepShouldITake();
-        } else {
             this._step += action;
+        } else if (/\d/g.test(action)) {
+            if (this._step.charAt(0) === WALK) {
+                this._step += action;
+            }
+
             if (this._inputLength === index) {
                 this._whatStepShouldITake();
             }
+        } else {
+            throw new Error('Given instruction doesn\'t match expected command of instruction');
         }
     }
 
@@ -64,10 +70,11 @@ class MAQEBOT {
      * @private
      */
     _whatStepShouldITake() {
-        if (this._step === '') {
+        if (this._step === '' || (this._step.length === 1 && this._step.charAt(0) === WALK)) {
             return;
         }
 
+        this._step = this._step.substring(1);
         switch (this.state) {
             case 0: // WEST
                 this.x -= parseInt(this._step, 10);

--- a/tests/maqe-bot.test.js
+++ b/tests/maqe-bot.test.js
@@ -30,6 +30,15 @@ describe('MAQEBOT', () => {
         assert.deepEqual(actual, expected);
     });
 
+    it('should complain about unexpected of instructions', () => {
+        try {
+            maqeBot.walkTheWalk('rw15rl15');
+            assert.fail('it should fail but pass');
+        } catch (err) {
+            assert.equal(err.message, 'Given instruction doesn\'t match expected command of instruction');
+        }
+    });
+
     describe('take the right step', () => {
         it('should change direction to right once', () => {
             const expected = { X: 0, Y: 0, Direction: 'East' };
@@ -91,6 +100,13 @@ describe('MAQEBOT', () => {
     });
 
     describe('take a walk', () => {
+        it('should do nothing if there is no walk instruction', () => {
+            const expected = { X: 0, Y: 0, Direction: 'North' };
+            const actual = maqeBot.walkTheWalk('15');
+
+            assert.deepEqual(actual, expected);
+        });
+
         it('should walk forward on north direction (N)', () => {
             const expected = { X: 0, Y: 15, Direction: 'North' };
             const actual = maqeBot.walkTheWalk('W15');


### PR DESCRIPTION
It's possible that the system will get instruction in unexpected manner
e.g.
Incorrect casing for instruction set
```
rw15rl15 
```

rather than

```
RW15RL15
```

or 

A step without instruction
```
R15
```

rather than

```
RW15
```